### PR TITLE
Ross delay modification

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -4,15 +4,16 @@
 #define FALSE 0
 #define TRUE 1
 
-#define MAX_TOUR_LENGTH 100
-#define MIN_CITY_SEPARATION 4
-#define MAX_CITY_SEPARATION 11
+#define MAX_TOUR_LENGTH 21
+#define MIN_CITY_SEPARATION 1
+#define MAX_CITY_SEPARATION 100
 
 #define BITS_TO_ENCODE_TOUR ((MAX_TOUR_LENGTH*MAX_TOUR_LENGTH) + MAX_TOUR_LENGTH) //equivalent to number of max unique gids
 #define MAX_INTS_NEEDED ((BITS_TO_ENCODE_TOUR / 64)+1)
 
 
 #define MSG_TIME_DELAY 1000
+
 
 typedef uint64_t compact_tour_part_t;
 

--- a/globals.h
+++ b/globals.h
@@ -4,7 +4,7 @@
 #define FALSE 0
 #define TRUE 1
 
-#define MAX_TOUR_LENGTH 20
+#define MAX_TOUR_LENGTH 100
 #define MIN_CITY_SEPARATION 4
 #define MAX_CITY_SEPARATION 11
 

--- a/globals.h
+++ b/globals.h
@@ -22,7 +22,6 @@ unsigned int nlp_per_pe;
 unsigned int custom_LPs_per_pe;
 int total_actors;
 int total_cities;
-int L;
 
 //GLOBALS
 

--- a/tsp.h
+++ b/tsp.h
@@ -29,7 +29,6 @@ typedef struct
 {
      uint64_t min_tour[MAX_INTS_NEEDED];
      uint64_t min_complete_tour[MAX_INTS_NEEDED];
-     int L;
      int* incomingWeights; //TODO for generalization, make into double
      int* outgoingWeights;
      tw_lpid* incomingNeighborIDs;

--- a/tsp.h
+++ b/tsp.h
@@ -28,18 +28,29 @@ Neil McGlohon
 typedef struct
 {
      uint64_t min_tour[MAX_INTS_NEEDED];
+     uint64_t min_complete_tour[MAX_INTS_NEEDED];
      int L;
      int* incomingWeights; //TODO for generalization, make into double
-     tw_lpid* neighborIDs;
+     int* outgoingWeights;
+     tw_lpid* incomingNeighborIDs;
+     tw_lpid* outgoingNeighborIDs;
      int self_place;
      int self_city;
      int rng_count;
      int min_tour_weight;
-     int num_neighbors;
+     int min_complete_tour_weight;
+     int num_incoming_neighbors;
+     int num_outgoing_neighbors;
      int msgs_sent;
      int msgs_rcvd;
      unsigned int complete_tour_msgs_rcvd;
 } tsp_actor_state;
+
+typedef enum
+{
+     TOUR = 1,
+     COMPLETE
+} tsp_msg_type;
 
 
 typedef struct
@@ -50,6 +61,7 @@ typedef struct
      int saved_rng_count;
      int saved_complete_tours;
      int saved_msgs_rcvd;
+     tsp_msg_type messType;
 } tsp_mess;
 
 

--- a/tsp.h
+++ b/tsp.h
@@ -27,7 +27,6 @@ Neil McGlohon
 //TODO order the declarations to optimize memory usage
 typedef struct
 {
-     uint64_t min_tour[MAX_INTS_NEEDED];
      uint64_t min_complete_tour[MAX_INTS_NEEDED];
      int* incomingWeights; //TODO for generalization, make into double
      int* outgoingWeights;
@@ -36,13 +35,14 @@ typedef struct
      int self_place;
      int self_city;
      int rng_count;
-     int min_tour_weight;
+     // int min_tour_weight;
      int min_complete_tour_weight;
      int num_incoming_neighbors;
      int num_outgoing_neighbors;
      int msgs_sent;
      int msgs_rcvd;
      unsigned int complete_tour_msgs_rcvd;
+     unsigned int self_complete_tours_made;
 } tsp_actor_state;
 
 typedef enum

--- a/tsp_driver.c
+++ b/tsp_driver.c
@@ -45,7 +45,7 @@ void tsp_init (tsp_actor_state *s, tw_lp *lp)
      s->self_city = (lp->gid)%total_cities;
      s->self_place = (lp->gid)/total_cities;
      s->rng_count = 0;
-     s->min_tour_weight = 99999;
+     // s->min_tour_weight = 99999;
      s->min_complete_tour_weight = 99999;
      s->complete_tour_msgs_rcvd = 0;
 
@@ -59,7 +59,7 @@ void tsp_init (tsp_actor_state *s, tw_lp *lp)
 
      for(int i = 0; i<MAX_INTS_NEEDED;i++)
      {
-          s->min_tour[i] = 0;
+          // s->min_tour[i] = 0;
           s->min_complete_tour[i] = 0;
      }
 
@@ -109,20 +109,23 @@ void tsp_prerun(tsp_actor_state *s, tw_lp *lp)
 
      if(self < total_cities) //only start on the first layer
      {
-          double init_time = tw_rand_unif(lp->rng);
-
-          tw_event *e = tw_event_new(self,init_time,lp);
-          tsp_mess *mess = tw_event_data(e);
-          mess->sender = self;
-          // mess->recipient = self;
-          for(int i = 0; i<MAX_INTS_NEEDED;i++)
+          if(s->self_city == 0)
           {
-               mess->tour_history[i] = 0;
-          }
+               double init_time = tw_rand_unif(lp->rng);
 
-          mess->tour_weight = 0;
-          mess->messType = TOUR;
-          tw_event_send(e);
+               tw_event *e = tw_event_new(self,init_time,lp);
+               tsp_mess *mess = tw_event_data(e);
+               mess->sender = self;
+               // mess->recipient = self;
+               for(int i = 0; i<MAX_INTS_NEEDED;i++)
+               {
+                    mess->tour_history[i] = 0;
+               }
+
+               mess->tour_weight = 0;
+               mess->messType = TOUR;
+               tw_event_send(e);
+          }
      }
 }
 
@@ -143,41 +146,22 @@ int is_in_tour(int* tour, int len, int input)
 
 void tsp_propogate_message(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_mst, tw_lp *lp, compact_tour_part_t working_tour[MAX_INTS_NEEDED], int new_tour_weight)
 {
-     // tw_stime now = tw_now(lp);
-
      int self_place = s->self_place;
 
      int self_city = s->self_city;
-
-     // tw_stime endTime = g_tw_ts_end - (.1*g_tw_ts_end);
-
-     // tw_stime myDelayWindowStart = ((self_place+1.0)/(total_cities+1.0))*endTime;
-     // tw_stime myUpperBoundDelay = ((self_city+1.0)/(total_cities)) * (1.0/(total_cities+1.0)) * endTime;
-
-     // printf("%i,%i: Delay = %f * %f\n",self_city,self_place,myUpperBoundDelay, tw_rand_unif(lp->rng));
-
 
 
      if(s->self_place < total_cities)
      {
           if(s->self_place == total_cities-1) //then you need to send to the original city
           {
-               tw_lpid first_gid = get_first_gid_in_tour(working_tour);
-               int city = get_city_from_gid(first_gid);
-
-               int weight_to_original = weight_matrix[city][s->self_city];
-
-
-               tw_lpid recipient = get_lp_gid( city ,s->self_place+1);
                s->msgs_sent++;
                s->rng_count++;
 
-               // printf("%d: ",s->self_city);
-               // for(int i = 0; i < total_cities+1; i++)
-               // {
-               //      printf("%d ",working_tour[i]);
-               // }
-               // printf(" sending to original %d\n",city);
+               tw_lpid first_gid = get_first_gid_in_tour(working_tour);
+               int city = get_city_from_gid(first_gid);
+               int weight_to_original = weight_matrix[city][s->self_city];
+               tw_lpid recipient = get_lp_gid( city ,s->self_place+1);
 
                tw_stime delay = weight_to_original*100 + tw_rand_unif(lp->rng)*.00001;
 
@@ -185,7 +169,6 @@ void tsp_propogate_message(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_mst, tw_l
                tw_event *e = tw_event_new(recipient,delay,lp);
                tsp_mess *mess = tw_event_data(e);
                mess->sender = lp->gid;
-               // mess->recipient = recipient;
                mess->tour_weight = new_tour_weight;
                mess->messType = TOUR;
 
@@ -200,7 +183,6 @@ void tsp_propogate_message(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_mst, tw_l
                {
                     int neighbor_city_id = s->incomingNeighborIDs[i];
 
-
                     int found = isInTour(neighbor_city_id,s->self_place,working_tour);
 
                     if(found == 0)
@@ -208,59 +190,46 @@ void tsp_propogate_message(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_mst, tw_l
                          s->msgs_sent++;
                          s->rng_count++;
 
-                         // for(int i = 0; i < total_cities+1; i++)
-                         // {
-                         //      printf("%d ",working_tour[i]);
-                         // }
-                         // printf("%i: sending to %d\n",s->self_city,neighbor_city_id);
-                         // // printf("%d: sending to %d\n",s->self_city,neighbor_city_id);
-
                          tw_lpid recipient = get_lp_gid(neighbor_city_id,s->self_place+1);
 
-                         // tw_stime timeToWindow = myDelayWindowStart - now;
-
-                         // tw_stime delay = (tw_rand_unif(lp->rng)*myUpperBoundDelay) + timeToWindow;
-
-                         tw_stime delay = weight_matrix[neighbor_city_id][s->self_city] + tw_rand_unif(lp->rng)*.00001;
-
-
-                         // printf("%i,%i: send message to arrive at: %f\n",self_city,self_place,now+delay);
+                         tw_stime delay = weight_matrix[neighbor_city_id][s->self_city]*100 + tw_rand_unif(lp->rng)*.01;
 
                          tw_event *e = tw_event_new(recipient,delay,lp);
                          tsp_mess *mess = tw_event_data(e);
                          mess->sender = lp->gid;
                          mess->messType = TOUR;
-                         // mess->recipient = recipient;
                          mess->tour_weight = new_tour_weight;
 
                          copy_uint64_array(working_tour,mess->tour_history,MAX_INTS_NEEDED);
 
-                         // for(int j = 0; j < total_cities+1;j++)
-                         // {
-                         //      mess->tour_history[j] = working_tour[j];
-                         // }
                          tw_event_send(e);
                     }
                }
           }
-
-
      }
 }
 
 void tsp_broadcast_complete(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_msg, tw_lp *lp)
 {
+     int actualTour[total_cities+1];
+     decodeTour(s->min_complete_tour,actualTour);
+     for(int i = 0; i < total_cities+1; i++)
+     {
+          printf("%i ",actualTour[i]);
+     }
+     printf("\n");
+
+
      for(int i = 0; i < total_cities; i++)
      {
           for(int j = 0; j < total_cities+1; j++)
           {
                tw_lpid recipient = get_lp_gid(i ,j);
-               tw_event *e = tw_event_new(recipient,tw_rand_unif(lp->rng)*.00001,lp);
+               tw_event *e = tw_event_new(recipient,tw_rand_unif(lp->rng)*.01,lp);
                tsp_mess *mess = tw_event_data(e);
                mess->sender = lp->gid;
                mess->messType = COMPLETE;
-               // mess->recipient = recipient;
-               copy_uint64_array(s->min_complete_tour,in_msg->tour_history,MAX_INTS_NEEDED);
+               copy_uint64_array(s->min_complete_tour,mess->tour_history,MAX_INTS_NEEDED);
                mess->tour_weight = s->min_complete_tour_weight;
                tw_event_send(e);
           }
@@ -285,7 +254,6 @@ void tsp_event_handler(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_msg, tw_lp *l
                int incoming_city = get_city_from_gid(in_msg->sender);
                // printf("%d,%d:Incoming City: %d\n",s->self_city,s->self_place,incoming_city);
 
-               // compact_tour_part_t  * working_tour = calloc(MAX_INTS_NEEDED,sizeof(compact_tour_part_t));
                compact_tour_part_t working_tour[MAX_INTS_NEEDED];
 
                copy_uint64_array(in_msg->tour_history,working_tour,MAX_INTS_NEEDED);
@@ -310,38 +278,45 @@ void tsp_event_handler(tsp_actor_state *s, tw_bf *bf, tsp_mess *in_msg, tw_lp *l
 
                if((new_tour_weight < s->min_complete_tour_weight))
                {
+                    printf("%i < %i\n",new_tour_weight,s->min_complete_tour_weight);
+                    // printf("%i,%i: new tour weight: %i\n",s->self_city,s->self_place,new_tour_weight);
                          if(s->self_place == total_cities) //you're the last city in the tour
                          {
-                              if(new_tour_weight < (s->min_tour_weight))
+
+                              if(new_tour_weight < (s->min_complete_tour_weight))
                               {
-                                   s->min_tour_weight = new_tour_weight;
+                                   printf("NEW BEST COMPLETE TOUR FOUND %i\n",new_tour_weight);
+
+                                   s->min_complete_tour_weight = new_tour_weight;
+
+
                                    copy_uint64_array(working_tour,s->min_complete_tour,MAX_INTS_NEEDED);
                                    tsp_broadcast_complete(s,bf,in_msg,lp);
                               }
-                              s->complete_tour_msgs_rcvd++;
+                              s->self_complete_tours_made++;
 
                          }
+                         else{
+                              //forward to the neighbors not currently in the tour
+                              tsp_propogate_message(s, bf, in_msg, lp, working_tour, new_tour_weight);
+                         }
 
-                         //forward to the neighbors not currently in the tour
-                         tsp_propogate_message(s, bf, in_msg, lp, working_tour, new_tour_weight);
+
                }
 
-          }
+          }break;
           case COMPLETE: //you're receiving a complete tour message, stop propogating weaker tours
           {
                // printf("%d,%d: Received COMPLETE mess\n",s->self_city,s->self_place);
-
-
-
+               s->complete_tour_msgs_rcvd++;
                if(in_msg->tour_weight <= s->min_complete_tour_weight)
                {
+                    // printf("%d,%d: updating min tour weight\n",s->self_city,s->self_place);
                     s->min_complete_tour_weight = in_msg->tour_weight;
-
-                    compact_tour_part_t working_tour[MAX_INTS_NEEDED];
 
                     copy_uint64_array(in_msg->tour_history,s->min_complete_tour,MAX_INTS_NEEDED);
                }
-          }
+          }break;
      }
 
 
@@ -376,7 +351,7 @@ void tsp_final(tsp_actor_state *s, tw_lp *lp)
      int self = lp->gid;
      if(s->self_place == total_cities)
      {
-          if(s->complete_tour_msgs_rcvd > 0)
+          if(s->self_complete_tours_made > 0)
           {
                int actualTour[total_cities+1];
                decodeTour(s->min_complete_tour,actualTour);
@@ -389,7 +364,7 @@ void tsp_final(tsp_actor_state *s, tw_lp *lp)
                }
                printf("\n");
 
-               printf("%d: Complete Tours: %d\n",s->self_city,s->complete_tour_msgs_rcvd);
+               printf("%d: Complete Tours: %d\n",s->self_city,s->self_complete_tours_made);
           }
 
 

--- a/tsp_main.c
+++ b/tsp_main.c
@@ -30,7 +30,6 @@ tw_lptype model_lps[] =
 int num_cities= 4;
 int min_fanout= 1;
 int max_fanout= 4;
-int max_len_valid = 100000000;
 
 //Command line opts
 const tw_optdef model_opts[] = {
@@ -38,7 +37,6 @@ const tw_optdef model_opts[] = {
      TWOPT_UINT("cities", num_cities, "Total cities in simulation"),
      TWOPT_UINT("minfanout", min_fanout, "Min Fanout of graph nodes (Not implemented yet)"),
      TWOPT_UINT("maxfanout", max_fanout, "Max Fanout of graph nodes (Not Implemented yet)"),
-     TWOPT_UINT("maxlen", max_len_valid, "Maximum length of a valid tour (TSP-Decision: NP-Complete Version)"),
      TWOPT_END()
 };
 
@@ -60,7 +58,6 @@ void displayModelSettings()
           printf("\tNLPs per PE:  %i\n", nlp_per_pe);
           printf("\tTotal Actors: %i\n", total_actors);
           printf("\tTotal Cities: %i\n", num_cities);
-          printf("\tMax Length Valid Tour: %i\n",max_len_valid);
           printf("\n");
           printf("\tuint64s needed: %i\n",MAX_INTS_NEEDED);
 
@@ -90,8 +87,6 @@ int rand_range(int low, int high)
 void initialize()
 {
      total_cities = num_cities;
-
-     L = max_len_valid;
 
      weight_matrix = (int**) calloc(num_cities,sizeof(int*));
      int i;


### PR DESCRIPTION
I have changed the way that the message delays were defined. Now the message delay is based on the outgoing weight (distance to the next city). Thus the first final position city to get a tour message should be very close to the optimal path. It then broadcasts to all other LPs of the best path. Investigate how this behaves as other LPs are processing messages.